### PR TITLE
Updated simplemap.js

### DIFF
--- a/resources/SimpleMap_Map.js
+++ b/resources/SimpleMap_Map.js
@@ -229,7 +229,7 @@ SimpleMap.prototype.sync = function (update) {
 		self.inputs.address.value = address;
 	});
 
-	if (update) return this.update(pos.lat, pos.lng, true);
+	if (update) return this.update(pos.lat(), pos.lng(), true);
 	return this;
 };
 


### PR DESCRIPTION
Updated simplemap.js to fix bug when the marker is dropped the lat lng input fields are filled with "return function a" due to js function returning a function and not the lat/lng value. This caused the google map to crash on reload and not show any maps.
